### PR TITLE
Revert "fix(harp reader): remove rows where the index is zero"

### DIFF
--- a/aeon/io/reader.py
+++ b/aeon/io/reader.py
@@ -79,12 +79,9 @@ class Harp(Reader):
         if self.columns is not None and payloadshape[1] < len(self.columns):
             data = pd.DataFrame(payload, index=seconds, columns=self.columns[: payloadshape[1]])
             data[self.columns[payloadshape[1] :]] = math.nan
+            return data
         else:
-            data = pd.DataFrame(payload, index=seconds, columns=self.columns)
-
-        # remove rows where the index is zero (why? corrupted data in harp files?)
-        data = data[data.index != 0]
-        return data
+            return pd.DataFrame(payload, index=seconds, columns=self.columns)
 
 
 class Chunk(Reader):


### PR DESCRIPTION
This reverts commit 12a7f9dabef2c98a2b4b4bff61d45733151ca650.

The original patch was introduced to handle a data corruption issue whereby harp `.bin` files would have large chunks of zeroes at the end, resulting in ingestion of invalid records.

Looking deeper into this it looks like what we have here is another instance of partial file copy corruption (i.e. the chunk was copied to CEPH while writing was still going on, and never replaced with the full version). Two observations support this:

1. all data at the end of affected files is zero (i.e. not just timestamps, but also the entire payload, message type, message checksum, etc). If such message had really been received from the hardware device, it would have been discarded at the source as invalid, since no valid message payload can have all bytes set to zero (e.g. at the very least the length field must be non-zero by definition);
2. if by some chance a message payload really did arrive with a zero timestamp, the `GroupByTime` chunking logic in the acquisition workflow would have placed that message in a different file, since the chunk ID (i.e. the hour component) would have been different.

This suggests there is likely no issue with either Harp device data or acquisition / logging logic, but rather a continuation of the problematic behavior of copying partial files, similar to a previously reported issue https://github.com/SainsburyWellcomeCentre/aeon_experiments/issues/547.

In the short-term, I was testing the low-level reader and these corrupt bytes at the end don't seem to prevent the data from being loaded. If the ingestion procedure is reading the data chunk-by-chunk, it should be possible to apply the filter downstream from the base low-level reader to preserve data integrity.

For example this could be incorporated into a modified reader by inheriting from the `Harp` reader class and overriding the `read` method:

```python
class HarpFilter(Harp):
    def read(self, file):
        data = super().read(self, file)
        # remove rows where the index is zero
        data = data[data.index != 0]
        return data
```

If a custom reader has already been developed to downsample the data at ingestion time, then this custom processing code could also be added at the end of that reader.

Long-term we need to find a way to eliminate partial copies altogether. If that was done there would be no need for any check, since by construction at the source we would never be able to generate such data from the acquisition workflows.