### PR TITLE
Use harp python library for base reader

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ license = { file = "license.md" }
 readme = "README.md"
 dependencies = [
   "dotmap",
+  "harp-python>=0.3.0",
   "matplotlib",
   "numpy>=1.21.0, <2",
   "opencv-python",
@@ -67,13 +68,13 @@ lint.select = [
   "SIM",
   "PL",
 ]
-line-length = 108
 lint.ignore = [
   "E731",
   "PLR0912", 
   "PLR0913",
   "PLR0915",
 ]
+line-length = 108
 extend-exclude = [
   ".git",
   ".github",

--- a/swc/aeon/io/reader.py
+++ b/swc/aeon/io/reader.py
@@ -4,29 +4,16 @@ from __future__ import annotations
 
 import datetime
 import json
-import math
 import os
 from pathlib import Path
 from typing import Any
 
+import harp
 import numpy as np
 import pandas as pd
 from dotmap import DotMap
 
 from swc.aeon.io.api import chunk_key
-
-_SECONDS_PER_TICK = 32e-6
-_payloadtypes = {
-    1: np.dtype(np.uint8),
-    2: np.dtype(np.uint16),
-    4: np.dtype(np.uint32),
-    8: np.dtype(np.uint64),
-    129: np.dtype(np.int8),
-    130: np.dtype(np.int16),
-    132: np.dtype(np.int32),
-    136: np.dtype(np.int64),
-    68: np.dtype(np.float32),
-}
 
 
 class Reader:
@@ -59,29 +46,7 @@ class Harp(Reader):
 
     def read(self, file):
         """Reads data from the specified Harp binary file."""
-        data = np.fromfile(file, dtype=np.uint8)
-        if len(data) == 0:
-            return pd.DataFrame(columns=self.columns, index=pd.DatetimeIndex([]))
-
-        stride = data[1] + 2
-        length = len(data) // stride
-        payloadsize = stride - 12
-        payloadtype = _payloadtypes[data[4] & ~0x10]
-        elementsize = payloadtype.itemsize
-        payloadshape = (length, payloadsize // elementsize)
-        seconds = np.ndarray(length, dtype=np.uint32, buffer=data, offset=5, strides=stride)
-        ticks = np.ndarray(length, dtype=np.uint16, buffer=data, offset=9, strides=stride)
-        seconds = ticks * _SECONDS_PER_TICK + seconds
-        payload = np.ndarray(
-            payloadshape, dtype=payloadtype, buffer=data, offset=11, strides=(stride, elementsize)
-        )
-
-        if self.columns is not None and payloadshape[1] < len(self.columns):
-            data = pd.DataFrame(payload, index=seconds, columns=self.columns[: payloadshape[1]])
-            data[self.columns[payloadshape[1] :]] = math.nan
-            return data
-        else:
-            return pd.DataFrame(payload, index=seconds, columns=self.columns)
+        return harp.read(file, columns=self.columns)
 
 
 class Chunk(Reader):


### PR DESCRIPTION
To ensure consistency and future maintainability, this PR refactors the base `Harp` reader to use the [harp-python](https://github.com/harp-tech/harp-python) library.

This library supports reading both timestamped and non-timestamped messages, and crucially it also has built-in support for automatically generating readers based on a device schema. This would allow us in the near future to implement a `StreamGroup` which can directly include a known harp device on the schema of an Aeon experiment, rather than having to write individual readers for each register.

One important caveat of this PR is that some backward-compatibility hacks were dropped in favor of more strict compliance. Specifically, the previous reader allowed the schema to specify only a subset of the columns from the full register payload, whereas with the new reader the schema must declare columns for all register payload values.

The original fallback was written at a time when developing new readers was somewhat cryptic and tedious. Writing new readers is much simpler now, and we should encourage experiment definitions to be thorough and complete about which exact file contents need to be present on each Harp data file. It should be possible to make explicit derived register classes to deal with any compatibility issues which may arise from this.