### PR TITLE
Disable strict module name comparisons

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ version_file = "swc/aeon/_version.py"
 include = ["swc*"]
 
 [tool.ruff]
+lint.flake8-builtins.builtins-strict-checking = false
 lint.select = [
   "E",
   "W",


### PR DESCRIPTION
The latest release of ruff [introduced new strict rules for A005](https://github.com/astral-sh/ruff/pull/15951) which triggered CI errors due to module name comparisons. The pyproject.toml file was updated to disable strict module name comparison checks.

Fixes #11 