### PR TITLE
Add optional column to track pose model provenance

### DIFF
--- a/swc/aeon/io/reader.py
+++ b/swc/aeon/io/reader.py
@@ -305,7 +305,7 @@ class Pose(Harp):
         self._model_root = model_root
         self._pattern_offset = pattern.rfind("_") + 1
 
-    def read(self, file: Path) -> pd.DataFrame:
+    def read(self, file: Path, include_model: bool = False) -> pd.DataFrame:
         """Reads data from the Harp-binarized tracking file."""
         # Get config file from `file`, then bodyparts from config file.
         model_dir = Path(file.stem[self._pattern_offset :].replace("_", "/")).parent
@@ -374,7 +374,8 @@ class Pose(Harp):
         data = pd.DataFrame(new_data, new_index, columns=new_columns)
 
         # Set model column using model_dir
-        data["model"] = model_dir
+        if include_model:
+            data["model"] = model_dir
         return data
 
     @staticmethod

--- a/swc/aeon/io/reader.py
+++ b/swc/aeon/io/reader.py
@@ -371,7 +371,11 @@ class Pose(Harp):
             new_data[i::n_parts, 2] = part
             new_data[i::n_parts, 3:6] = data.values[:, min_col:max_col]
             new_index[i::n_parts] = data.index.values
-        return pd.DataFrame(new_data, new_index, columns=new_columns)
+        data = pd.DataFrame(new_data, new_index, columns=new_columns)
+
+        # Set model column using model_dir
+        data["model"] = model_dir
+        return data
 
     @staticmethod
     def get_class_names(config_file: Path) -> list[str]:

--- a/tests/io/test_reader.py
+++ b/tests/io/test_reader.py
@@ -46,5 +46,13 @@ def test_Pose_read_local_model_dir_with_missing_part_names():
         aeon.load(pose_path / "missing-part-names", social03.CameraTop.Pose)
 
 
+@pytest.mark.api
+def test_Pose_read_local_model_dir_with_model_provenance():
+    """Test that the Pose reader can read data while keeping track of model provenance."""
+    data = aeon.load(pose_path / "centered-instance", social03.CameraTop.Pose, include_model=True)
+    assert len(data) > 0
+    assert "model" in data.columns
+
+
 if __name__ == "__main__":
     pytest.main()


### PR DESCRIPTION
Currently the pose reader internally extracts the `model_dir` from the file name in order to access model parameters. However, which exact model is used is not currently returned with the result data frame.

To be able to keep track and manipulate the pose model provenance we add a new column `model` storing the model directory path stored in the filename.

Sadly pandas does not optimize for repeated strings in data series. Since many datasets are expected to return large numbers of body parts and identities for each frame, and the model directory paths can be potentially long, we decided to exclude this column from regular loading by default.

Instead, we allow for an optional boolean parameter `include_model` in the reader which can be passed using `aeon.load` keyword arguments, e.g.:

```python
aeon.load(root, pose, include_model=True)
```

Fixes #14 