### PR TITLE
Fix distance calculation to use iloc for indexing

### DIFF
--- a/src/swc/aeon/analysis/utils.py
+++ b/src/swc/aeon/analysis/utils.py
@@ -20,7 +20,7 @@ def distancetravelled(angle, radius=4.0):
     clickdown = (turns > jumpthreshold).astype(int) * -1
     turns = (clickup + clickdown).cumsum()
     distance = 2 * np.pi * radius * (turns + angle / maxvalue)
-    distance = distance - distance[0]
+    distance = distance - distance.iloc[0]
     return distance
 
 

--- a/tests/test_unit/analysis/test_utils.py
+++ b/tests/test_unit/analysis/test_utils.py
@@ -1,0 +1,21 @@
+"""Tests for the `swc.aeon.analysis.utils` module."""
+
+import pytest
+
+from swc.aeon.analysis import utils
+from swc.aeon.io.api import load
+from tests.schema import exp02
+
+
+@pytest.mark.parametrize(
+    ("radius", "expected_sum"),
+    [(0, 0), (4, -170), (-4, 170)],
+    ids=["zero radius", "positive radius", "negative radius"],
+)
+def test_distancetravelled(monotonic_dir, radius, expected_sum):
+    """Test `distancetravelled` correctly computes the expected sum (down to the closest integer)
+    for the specified test file.
+    """
+    data = load(monotonic_dir, exp02.Patch2.Encoder)
+    result = utils.distancetravelled(data.angle, radius)
+    assert int(result.sum()) == expected_sum


### PR DESCRIPTION
This fixes the FutureWarning:
Series.__getitem__ treating keys as positions is deprecated. In a future version, integer keys will always be treated as labels (consistent with DataFrame behavior). To access a value by position, use `ser.iloc[pos]`