### PR TITLE
Dynamically assign `device_type` based on subclass name

### DIFF
--- a/src/swc/aeon/schema/base.py
+++ b/src/swc/aeon/schema/base.py
@@ -5,7 +5,7 @@ import os
 from collections.abc import Callable
 from functools import cached_property
 from pathlib import Path
-from typing import Any, Self, TypeVar
+from typing import Any, Literal, Self, TypeVar
 
 import pandas as pd
 from pydantic import BaseModel, ConfigDict, Field, TypeAdapter, model_validator
@@ -65,10 +65,21 @@ class Experiment(BaseSchema):
     )
 
 
-class Device(BaseSchema):
+class DeviceTypeMixin:
+    """Mixin to set `device_type` to the subclass name for hardware device models."""
+
+    def __init_subclass__(cls, **kwargs):
+        """Injects `device_type` as a Literal of the subclass name."""
+        super().__init_subclass__(**kwargs)
+        name = cls.__name__
+        cls.__annotations__["device_type"] = Literal[name]
+        cls.device_type = name
+
+
+class Device(DeviceTypeMixin, BaseSchema):
     """The base class for creating hardware device models."""
 
-    device_type: Any = Field(description="The type of the device.")
+    device_type: Any = Field(default=None, description="The type of the device.")
 
 
 class Dataset(BaseSchema):

--- a/src/swc/aeon/schema/environment.py
+++ b/src/swc/aeon/schema/environment.py
@@ -1,7 +1,5 @@
 """Classes for defining environment configuration models."""
 
-from typing import Literal
-
 from pydantic import Field
 
 from swc.aeon.schema.base import BaseSchema, Device
@@ -30,7 +28,6 @@ class LightCycle(BaseSchema):
 class WeightScale(Device):
     """Represents acquisition functionality for automated habitat weighing scales."""
 
-    device_type: Literal["WeightScale"] = "WeightScale"
     port_name: str = Field(examples=["COM"], description="The name of the device serial port.")
     filter_window: int = Field(
         default=40, description="Sliding window size of the weight linear regression filter."

--- a/src/swc/aeon/schema/harp.py
+++ b/src/swc/aeon/schema/harp.py
@@ -1,6 +1,6 @@
 """Classes for defining Harp device configuration models."""
 
-from typing import ClassVar, Literal
+from typing import ClassVar
 
 from pydantic import Field
 
@@ -17,68 +17,58 @@ class HarpDevice(Device):
 class HarpInputExpander(HarpDevice):
     """Represents a Harp Input Expander device."""
 
-    device_type: Literal["HarpInputExpander"] = "HarpInputExpander"
     who_am_i: ClassVar[int] = 1106
 
 
 class HarpOutputExpander(HarpDevice):
     """Represents a Harp Output Expander device."""
 
-    device_type: Literal["HarpOutputExpander"] = "HarpOutputExpander"
     who_am_i: ClassVar[int] = 1108
 
 
 class HarpClockSynchronizer(HarpDevice):
     """Represents a Harp Clock Synchronizer device."""
 
-    device_type: Literal["HarpClockSynchronizer"] = "HarpClockSynchronizer"
     who_am_i: ClassVar[int] = 1152
 
 
 class HarpTimestampGeneratorGen3(HarpDevice):
     """Represents a Harp Timestamp Generator Gen3 device."""
 
-    device_type: Literal["HarpTimestampGeneratorGen3"] = "HarpTimestampGeneratorGen3"
     who_am_i: ClassVar[int] = 1158
 
 
 class HarpCameraController(HarpDevice):
     """Represents a Harp Camera Controller device."""
 
-    device_type: Literal["HarpCameraController"] = "HarpCameraController"
     who_am_i: ClassVar[int] = 1168
 
 
 class HarpCameraControllerGen2(HarpDevice):
     """Represents a Harp Camera Controller Gen2 device."""
 
-    device_type: Literal["HarpCameraControllerGen2"] = "HarpCameraControllerGen2"
     who_am_i: ClassVar[int] = 1170
 
 
 class HarpBehavior(HarpDevice):
     """Represents a Harp Behavior device."""
 
-    device_type: Literal["HarpBehavior"] = "HarpBehavior"
     who_am_i: ClassVar[int] = 1216
 
 
 class HarpAudioSwitch(HarpDevice):
     """Represents a Harp Audio Switch device."""
 
-    device_type: Literal["HarpAudioSwitch"] = "HarpAudioSwitch"
     who_am_i: ClassVar[int] = 1248
 
 
 class HarpSoundCard(HarpDevice):
     """Represents a Harp Sound Card device."""
 
-    device_type: Literal["HarpSoundCard"] = "HarpSoundCard"
     who_am_i: ClassVar[int] = 1280
 
 
 class HarpRfidReader(HarpDevice):
     """Represents a Harp RFID Reader device."""
 
-    device_type: Literal["HarpRfidReader"] = "HarpRfidReader"
     who_am_i: ClassVar[int] = 2094

--- a/src/swc/aeon/schema/video.py
+++ b/src/swc/aeon/schema/video.py
@@ -1,7 +1,5 @@
 """Classes for defining video capture device configuration models."""
 
-from typing import Literal
-
 from pydantic import Field
 
 from swc.aeon.schema.base import Device
@@ -10,7 +8,6 @@ from swc.aeon.schema.base import Device
 class SpinnakerCamera(Device):
     """Represents a FLIR Spinnaker camera acquisition module."""
 
-    device_type: Literal["SpinnakerCamera"] = "SpinnakerCamera"
     serial_number: str = Field(examples=["00000"], description="The serial number of the camera.")
     exposure_time: float = Field(
         default=1000,

--- a/tests/data/metadata/2025-12-02T13-45-23/Metadata.json
+++ b/tests/data/metadata/2025-12-02T13-45-23/Metadata.json
@@ -10,7 +10,7 @@
     }
   },
   "camera": {
-    "device_type": "SpinnakerCamera",
+    "device_type": "DummyCamera",
     "serial_number": "00000",
     "exposure_time": 1000.0,
     "gain": 0.0,
@@ -19,7 +19,7 @@
   },
   "feeder": {
     "Feeder1": {
-      "device_type": "HarpOutputExpander",
+      "device_type": "DummyFeeder",
       "port_name": "COM6",
       "pellet_delivery_retry_count": 2,
       "pellet_delivery_timeout": 1.0,

--- a/tests/test_unit/schema/test_base.py
+++ b/tests/test_unit/schema/test_base.py
@@ -2,8 +2,9 @@
 
 import os
 from enum import StrEnum
-from typing import ClassVar, Literal
+from typing import ClassVar, Literal, get_args, get_origin
 
+import pytest
 from pydantic import Field
 
 from swc.aeon.io.api import load
@@ -18,7 +19,6 @@ from swc.aeon.schema.video import SpinnakerCamera
 class DummyHarpDevice(HarpDevice):
     """A dummy Harp device."""
 
-    device_type: Literal["DummyHarpDevice"] = "DummyHarpDevice"
     who_am_i: ClassVar[int] = 0000
 
     @data_reader
@@ -106,3 +106,19 @@ def test_dataset_read_metadata(test_data_dir):
     """Test that dataset Metadata is loaded successfully."""
     metadata = load(test_data_dir, Metadata(DummyDataset))
     assert len(metadata) > 0
+
+
+@pytest.mark.parametrize(
+    ("device_instance", "expected_device_type"),
+    [
+        (DummyHarpDevice(port_name="COM3"), "DummyHarpDevice"),
+        (DummyCamera(serial_number="12345"), "DummyCamera"),
+    ],
+)
+def test_device_type_mixin(device_instance, expected_device_type):
+    """Test that DeviceTypeMixin correctly sets device_type to the subclass name."""
+    assert device_instance.device_type == expected_device_type
+    # Check that the device_type annotation is Literal[expected_device_type]
+    annotation = type(device_instance).__annotations__["device_type"]
+    assert get_origin(annotation) == Literal
+    assert get_args(annotation) == (expected_device_type,)


### PR DESCRIPTION
addresses #67 ?

I updated device_type in the test Metadata.json to match the subclasses defined in test_base.py (is this correct?)
