### PR TITLE
Remove device discriminator class

### DIFF
--- a/src/swc/aeon/schema/__init__.py
+++ b/src/swc/aeon/schema/__init__.py
@@ -1,6 +1,6 @@
 """Modules for building aeon schemas."""
 
 # Set imports available directly under 'swc.aeon.schema'
-from swc.aeon.schema.base import BaseSchema, Dataset, Device, Experiment, Metadata, data_reader
+from swc.aeon.schema.base import BaseSchema, Dataset, Experiment, Metadata, data_reader
 
-__all__ = ["BaseSchema", "Experiment", "Device", "Dataset", "Metadata", "data_reader"]
+__all__ = ["BaseSchema", "Experiment", "Dataset", "Metadata", "data_reader"]

--- a/src/swc/aeon/schema/base.py
+++ b/src/swc/aeon/schema/base.py
@@ -5,7 +5,7 @@ import os
 from collections.abc import Callable
 from functools import cached_property
 from pathlib import Path
-from typing import Any, Self, TypeVar
+from typing import Self, TypeVar
 
 import pandas as pd
 from pydantic import BaseModel, ConfigDict, Field, TypeAdapter, model_validator
@@ -63,12 +63,6 @@ class Experiment(BaseSchema):
     repository_url: str = Field(
         description="The URL of the git repository used to version experiment source code."
     )
-
-
-class Device(BaseSchema):
-    """The base class for creating hardware device models."""
-
-    device_type: Any = Field(description="The type of the device.")
 
 
 class Dataset(BaseSchema):

--- a/src/swc/aeon/schema/environment.py
+++ b/src/swc/aeon/schema/environment.py
@@ -1,10 +1,8 @@
 """Classes for defining environment configuration models."""
 
-from typing import Literal
-
 from pydantic import Field
 
-from swc.aeon.schema.base import BaseSchema, Device
+from swc.aeon.schema.base import BaseSchema
 
 
 class LightCycle(BaseSchema):
@@ -27,10 +25,9 @@ class LightCycle(BaseSchema):
     )
 
 
-class WeightScale(Device):
+class WeightScale(BaseSchema):
     """Represents acquisition functionality for automated habitat weighing scales."""
 
-    device_type: Literal["WeightScale"] = "WeightScale"
     port_name: str = Field(examples=["COM"], description="The name of the device serial port.")
     filter_window: int = Field(
         default=40, description="Sliding window size of the weight linear regression filter."

--- a/src/swc/aeon/schema/harp.py
+++ b/src/swc/aeon/schema/harp.py
@@ -1,13 +1,13 @@
 """Classes for defining Harp device configuration models."""
 
-from typing import ClassVar, Literal
+from typing import ClassVar
 
 from pydantic import Field
 
-from swc.aeon.schema.base import Device
+from swc.aeon.schema.base import BaseSchema
 
 
-class HarpDevice(Device):
+class HarpDevice(BaseSchema):
     """A base class for creating Harp device models."""
 
     who_am_i: ClassVar[int] = Field(description="The unique identifier for the device type.")
@@ -17,68 +17,58 @@ class HarpDevice(Device):
 class HarpInputExpander(HarpDevice):
     """Represents a Harp Input Expander device."""
 
-    device_type: Literal["HarpInputExpander"] = "HarpInputExpander"
     who_am_i: ClassVar[int] = 1106
 
 
 class HarpOutputExpander(HarpDevice):
     """Represents a Harp Output Expander device."""
 
-    device_type: Literal["HarpOutputExpander"] = "HarpOutputExpander"
     who_am_i: ClassVar[int] = 1108
 
 
 class HarpClockSynchronizer(HarpDevice):
     """Represents a Harp Clock Synchronizer device."""
 
-    device_type: Literal["HarpClockSynchronizer"] = "HarpClockSynchronizer"
     who_am_i: ClassVar[int] = 1152
 
 
 class HarpTimestampGeneratorGen3(HarpDevice):
     """Represents a Harp Timestamp Generator Gen3 device."""
 
-    device_type: Literal["HarpTimestampGeneratorGen3"] = "HarpTimestampGeneratorGen3"
     who_am_i: ClassVar[int] = 1158
 
 
 class HarpCameraController(HarpDevice):
     """Represents a Harp Camera Controller device."""
 
-    device_type: Literal["HarpCameraController"] = "HarpCameraController"
     who_am_i: ClassVar[int] = 1168
 
 
 class HarpCameraControllerGen2(HarpDevice):
     """Represents a Harp Camera Controller Gen2 device."""
 
-    device_type: Literal["HarpCameraControllerGen2"] = "HarpCameraControllerGen2"
     who_am_i: ClassVar[int] = 1170
 
 
 class HarpBehavior(HarpDevice):
     """Represents a Harp Behavior device."""
 
-    device_type: Literal["HarpBehavior"] = "HarpBehavior"
     who_am_i: ClassVar[int] = 1216
 
 
 class HarpAudioSwitch(HarpDevice):
     """Represents a Harp Audio Switch device."""
 
-    device_type: Literal["HarpAudioSwitch"] = "HarpAudioSwitch"
     who_am_i: ClassVar[int] = 1248
 
 
 class HarpSoundCard(HarpDevice):
     """Represents a Harp Sound Card device."""
 
-    device_type: Literal["HarpSoundCard"] = "HarpSoundCard"
     who_am_i: ClassVar[int] = 1280
 
 
 class HarpRfidReader(HarpDevice):
     """Represents a Harp RFID Reader device."""
 
-    device_type: Literal["HarpRfidReader"] = "HarpRfidReader"
     who_am_i: ClassVar[int] = 2094

--- a/src/swc/aeon/schema/video.py
+++ b/src/swc/aeon/schema/video.py
@@ -1,16 +1,13 @@
 """Classes for defining video capture device configuration models."""
 
-from typing import Literal
-
 from pydantic import Field
 
-from swc.aeon.schema.base import Device
+from swc.aeon.schema.base import BaseSchema
 
 
-class SpinnakerCamera(Device):
+class SpinnakerCamera(BaseSchema):
     """Represents a FLIR Spinnaker camera acquisition module."""
 
-    device_type: Literal["SpinnakerCamera"] = "SpinnakerCamera"
     serial_number: str = Field(examples=["00000"], description="The serial number of the camera.")
     exposure_time: float = Field(
         default=1000,

--- a/tests/test_unit/schema/test_base.py
+++ b/tests/test_unit/schema/test_base.py
@@ -2,7 +2,7 @@
 
 import os
 from enum import StrEnum
-from typing import ClassVar, Literal
+from typing import ClassVar
 
 from pydantic import Field
 
@@ -18,7 +18,6 @@ from swc.aeon.schema.video import SpinnakerCamera
 class DummyHarpDevice(HarpDevice):
     """A dummy Harp device."""
 
-    device_type: Literal["DummyHarpDevice"] = "DummyHarpDevice"
     who_am_i: ClassVar[int] = 0000
 
     @data_reader


### PR DESCRIPTION
Avoid depending on a common property as an implicit discriminator. For polymorphic designs, named discriminator types can be added as required.

The base `Device` class was removed as it was left empty. `BaseSchema` should be used instead in the few places where any breakage is observed.

Fixes #67 