### PR TITLE
Disable uv caching for publish job in CI workflow

### DIFF
--- a/.github/workflows/swc-aeon.yml
+++ b/.github/workflows/swc-aeon.yml
@@ -110,6 +110,7 @@ jobs:
         uses: astral-sh/setup-uv@v7
         with:
           python-version: "3.13"
+          enable-cache: false
 
       # -------------------------------------------------------- Download built packages
       - name: Download built packages


### PR DESCRIPTION
Because the publish step only uses uv for publishing from built files (and not producing any uv-cacheable content, e.g. no dependencies were downloaded by uv), there isn't a cache which setup-uv expects to find at cleanup time.

The alternative would be to keep `enable-cache` as true (default) and set `ignore-nothing-to-cache: true` 

Closes #73 