### PR TITLE
Add unit tests for analysis modules

### DIFF
--- a/src/swc/aeon/analysis/movies.py
+++ b/src/swc/aeon/analysis/movies.py
@@ -44,7 +44,7 @@ def gridframes(frames, width, height, shape: None | int | tuple[int, int] = None
 
 def averageframes(frames):
     """Returns the average of the specified collection of frames."""
-    return cv2.convertScaleAbs(np.sum(np.multiply(1 / len(frames), frames)))
+    return cv2.convertScaleAbs(np.sum(np.multiply(1 / len(frames), frames), axis=0))
 
 
 def groupframes(frames, n, fun):

--- a/src/swc/aeon/analysis/movies.py
+++ b/src/swc/aeon/analysis/movies.py
@@ -50,19 +50,19 @@ def averageframes(frames):
 def groupframes(frames, n, fun):
     """Applies the specified function to each group of n-frames.
 
+    Incomplete final groups (when len(frames) is not divisible by n) are dropped.
+
     :param iterable frames: A sequence of frames to process.
     :param int n: The number of frames in each group.
     :param callable fun: The function used to process each group of frames.
     :return: An iterable returning the results of applying the function to each group.
     """
-    i = 0
     group = []
     for frame in frames:
         group.append(frame)
         if len(group) >= n:
             yield fun(group)
             group.clear()
-            i = i + 1
 
 
 def triggerclip(data, events, before=None, after=None):

--- a/src/swc/aeon/analysis/utils.py
+++ b/src/swc/aeon/analysis/utils.py
@@ -156,5 +156,4 @@ def activepatch(wheel, in_patch):
     exit_patch = in_patch.astype(np.int8).diff() < 0
     in_wheel = (wheel.diff().rolling("1s").sum() > 1).reindex(in_patch.index, method="pad")
     epochs = exit_patch.cumsum()
-    # return in_wheel.groupby(epochs).apply(lambda x: x.cumsum()) > 0
-    return in_wheel.groupby(epochs).cummax()
+    return in_wheel.groupby(epochs).apply(lambda x: x.cumsum()) > 0

--- a/src/swc/aeon/analysis/utils.py
+++ b/src/swc/aeon/analysis/utils.py
@@ -156,4 +156,5 @@ def activepatch(wheel, in_patch):
     exit_patch = in_patch.astype(np.int8).diff() < 0
     in_wheel = (wheel.diff().rolling("1s").sum() > 1).reindex(in_patch.index, method="pad")
     epochs = exit_patch.cumsum()
-    return in_wheel.groupby(epochs).apply(lambda x: x.cumsum()) > 0
+    # return in_wheel.groupby(epochs).apply(lambda x: x.cumsum()) > 0
+    return in_wheel.groupby(epochs).cummax()

--- a/tests/test_unit/analysis/test_movies.py
+++ b/tests/test_unit/analysis/test_movies.py
@@ -1,0 +1,223 @@
+"""Tests for the `swc.aeon.analysis.movies` module."""
+
+from unittest.mock import ANY, patch
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from swc.aeon.analysis import movies
+
+
+def _frame(height, width, value=0):
+    """Returns a frame of the specified dimensions and pixel value."""
+    return np.full((height, width, 3), value, dtype=np.uint8)
+
+
+def _clip_data(n_clips, frames_per_clip):
+    """Returns a DataFrame that mimics triggerclip output,
+    with n_clips * frames_per_clip rows and
+    "clip_sequence", "frame_sequence", "_path", and "_frame" columns.
+    """
+    rows = []
+    for clip_i in range(n_clips):
+        for frame_i in range(frames_per_clip):
+            rows.append(
+                {
+                    "clip_sequence": clip_i,
+                    "frame_sequence": frame_i,
+                    "_path": f"v{clip_i}.avi",
+                    "_frame": frame_i,
+                }
+            )
+    return pd.DataFrame(rows)
+
+
+def _data_with_times(n, freq="1s", start="2022-01-01 10:00:00"):
+    """Returns a DataFrame with n rows, indexed by a DatetimeIndex starting at start and spaced by freq."""
+    times = pd.date_range(start, periods=n, freq=freq)
+    return pd.DataFrame({"value": range(n)}, index=pd.DatetimeIndex(times, name="time"))
+
+
+@pytest.mark.parametrize(
+    ("width", "height", "shape", "n_frames", "checks"),
+    [
+        (
+            20,
+            20,
+            None,
+            1,
+            [(10, 10, 60)],
+        ),
+        (
+            20,
+            20,
+            4,
+            4,
+            [(5, 5, 60), (5, 15, 120), (15, 5, 180), (15, 15, 240)],
+        ),
+        (
+            40,
+            20,
+            (2, 2),
+            4,
+            [(5, 10, 60), (5, 30, 120), (15, 10, 180), (15, 30, 240)],
+        ),
+        (
+            20,
+            20,
+            (2, 2),
+            1,
+            [(5, 5, 60), (5, 15, 0), (15, 5, 0), (15, 15, 0)],
+        ),
+        (
+            20,
+            20,
+            (1, 1),
+            1,
+            [(10, 10, 60)],
+        ),
+    ],
+    ids=[
+        "shape=None (default) uses all frames",
+        "shape as number of frames, auto-calculates square grid",
+        "shape as grid (rows, cols) tuple",
+        "fewer frames than cells, empty cells are zero",
+        "single frame with explicit 1x1 shape fills the entire grid",
+    ],
+)
+def test_gridframes(width, height, shape, n_frames, checks):
+    """Test gridframes places frames in correct grid cells using varying parameters."""
+    # Create frames with different pixel values to identify them in the grid
+    frames = [_frame(5, 5, (i + 1) * 60) for i in range(n_frames)]
+    result = movies.gridframes(frames, width=width, height=height, shape=shape)
+    assert result.shape == (height, width, 3)
+    for row, col, expected in checks:
+        assert result[row, col, 0] == expected
+
+
+@pytest.mark.xfail(reason="np.sum in averageframes has no axis, reduces frames to scalar")
+@pytest.mark.parametrize(
+    ("frames", "expected"),
+    [
+        ([_frame(4, 4, 100)], _frame(4, 4, 100)),
+        ([_frame(4, 4, 50), _frame(4, 4, 50)], _frame(4, 4, 50)),
+        ([_frame(4, 4, 0), _frame(4, 4, 100)], _frame(4, 4, 50)),
+    ],
+    ids=[
+        "average of single frame is the same frame",
+        "average of identical frames is the same frame",
+        "average of black and white frames is grey frame at mid-value",
+    ],
+)
+def test_averageframes(frames, expected):
+    """Test averageframes with varying frame inputs.
+
+    This test currently fails as averageframes calls np.sum with no axis,
+    which reduces all pixel values to a scalar before convertScaleAbs,
+    so the output shape does not match the input frame shape.
+    The expected behaviour is described in the test cases, and this failing test
+    serves as a regression test.
+    """
+    result = movies.averageframes(frames)
+    assert result.shape == expected.shape
+    np.testing.assert_array_equal(result, expected)
+
+
+@pytest.mark.parametrize(
+    ("frames", "n", "fun", "expected"),
+    [
+        (list(range(6)), 2, list, [[0, 1], [2, 3], [4, 5]]),
+        (list(range(5)), 2, list, [[0, 1], [2, 3]]),
+        ([], 2, list, []),
+        ([1, 2, 3], 1, list, [[1], [2], [3]]),
+        ([np.array([1, 2]), np.array([3, 4])], 1, np.sum, [3, 7]),
+    ],
+    ids=[
+        "group 6 frames into groups of 2",
+        "incomplete final group is dropped",
+        "empty input produces no groups",
+        "n=1 yields each element as its own group",
+        "apply sum to each group",
+    ],
+)
+def test_groupframes(frames, n, fun, expected):
+    """Test groupframes with varying inputs and functions."""
+    result = list(movies.groupframes(frames, n, fun))
+    assert result == expected
+
+
+@pytest.mark.parametrize(
+    ("events", "before", "after", "expected_values", "expected_frame_seq", "expected_clip_seq"),
+    [
+        (pd.DatetimeIndex(["2022-01-01 10:00:05"]), None, None, [5], [0], [0]),
+        (
+            pd.DatetimeIndex(["2022-01-01 10:00:05"]),
+            pd.Timedelta("2s"),
+            None,
+            [3, 4, 5],
+            [0, 1, 2],
+            [0, 0, 0],
+        ),
+        (
+            pd.DatetimeIndex(["2022-01-01 10:00:05"]),
+            None,
+            pd.Timedelta("2s"),
+            [5, 6, 7],
+            [0, 1, 2],
+            [0, 0, 0],
+        ),
+        (
+            pd.DatetimeIndex(["2022-01-01 10:00:05"]),
+            pd.Timedelta("2s"),
+            pd.Timedelta("2s"),
+            [3, 4, 5, 6, 7],
+            [0, 1, 2, 3, 4],
+            [0, 0, 0, 0, 0],
+        ),
+        (
+            pd.Series(1, index=pd.DatetimeIndex(["2022-01-01 10:00:03", "2022-01-01 10:00:07"])),
+            None,
+            None,
+            [3, 7],
+            [0, 0],
+            [0, 1],
+        ),
+    ],
+    ids=["default", "before only", "after only", "before and after", "multiple events as Series"],
+)
+def test_triggerclip(events, before, after, expected_values, expected_frame_seq, expected_clip_seq):
+    """Test triggerclip selects correct rows for each before/after and event combination."""
+    data = _data_with_times(10)
+    result = movies.triggerclip(data, events, before=before, after=after)
+    assert list(result["value"]) == expected_values
+    assert list(result["frame_sequence"]) == expected_frame_seq
+    assert list(result["clip_sequence"]) == expected_clip_seq
+
+
+def test_collatemovie():
+    """Test collatemovie yields one mean-aggregated frame per distinct frame_sequence value."""
+    clipdata = _clip_data(n_clips=2, frames_per_clip=2)
+    # sorted order: (frame_seq=0,clip0)=50, (frame_seq=0,clip1)=100,
+    #               (frame_seq=1,clip0)=100, (frame_seq=1,clip1)=150
+    frames = [_frame(4, 4, 50), _frame(4, 4, 100), _frame(4, 4, 100), _frame(4, 4, 150)]
+    fun = lambda g: np.mean(g, axis=0)
+    with patch("swc.aeon.analysis.movies.video.frames", return_value=iter(frames)):
+        result = list(movies.collatemovie(clipdata, fun))
+    assert len(result) == 2
+    np.testing.assert_array_equal(result[0], _frame(4, 4, 75))
+    np.testing.assert_array_equal(result[1], _frame(4, 4, 125))
+
+
+def test_gridmovie():
+    """Test gridmovie forwards width, height, and shape to gridframes."""
+    clipdata = _clip_data(n_clips=2, frames_per_clip=1)
+    frames = [_frame(10, 10), _frame(10, 10)]
+    with (
+        patch("swc.aeon.analysis.movies.gridframes") as mock_gf,
+        patch("swc.aeon.analysis.movies.video.frames", return_value=iter(frames)),
+    ):
+        mock_gf.return_value = _frame(20, 30)
+        # use list to consume generator or mock never fires
+        list(movies.gridmovie(clipdata, width=20, height=30, shape=(2, 1)))
+        mock_gf.assert_called_with(ANY, 20, 30, (2, 1))

--- a/tests/test_unit/analysis/test_movies.py
+++ b/tests/test_unit/analysis/test_movies.py
@@ -96,7 +96,6 @@ def test_gridframes(width, height, shape, n_frames, checks):
         assert result[row, col, 0] == expected
 
 
-@pytest.mark.xfail(reason="np.sum in averageframes has no axis, reduces frames to scalar")
 @pytest.mark.parametrize(
     ("frames", "expected"),
     [
@@ -111,14 +110,7 @@ def test_gridframes(width, height, shape, n_frames, checks):
     ],
 )
 def test_averageframes(frames, expected):
-    """Test averageframes with varying frame inputs.
-
-    This test currently fails as averageframes calls np.sum with no axis,
-    which reduces all pixel values to a scalar before convertScaleAbs,
-    so the output shape does not match the input frame shape.
-    The expected behaviour is described in the test cases, and this failing test
-    serves as a regression test.
-    """
+    """Test averageframes with varying frame inputs."""
     result = movies.averageframes(frames)
     assert result.shape == expected.shape
     np.testing.assert_array_equal(result, expected)

--- a/tests/test_unit/analysis/test_plotting.py
+++ b/tests/test_unit/analysis/test_plotting.py
@@ -1,0 +1,166 @@
+"""Tests for the `swc.aeon.analysis.plotting` module."""
+
+import matplotlib as mpl
+
+mpl.use("Agg")
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import pytest
+from matplotlib.collections import LineCollection
+
+from swc.aeon.analysis import plotting
+
+
+@pytest.fixture(autouse=True)
+def close_figures():
+    """Automatically close all figures after each test."""
+    yield
+    plt.close("all")
+
+
+def _position(n=100, seed=42):
+    """Returns a DataFrame mimicking position data with x, y coordinates."""
+    rng = np.random.default_rng(seed)
+    return pd.DataFrame({"x": rng.uniform(0, 100, n), "y": rng.uniform(0, 100, n)})
+
+
+def _events(n=20, freq="1s", start="2022-01-01 10:00:00"):
+    """Returns a Series mimicking event data, with DatetimeIndex."""
+    times = pd.date_range(start, periods=n, freq=freq)
+    return pd.Series(1, index=pd.DatetimeIndex(times, name="time"))
+
+
+@pytest.mark.parametrize(
+    ("frequency", "ax", "kwargs", "expected_bins"),
+    [
+        (10, None, {"bins": 10}, 10),
+        (10, plt.subplots()[1], {"bins": 10}, 10),
+        (20, None, {"bins": 5}, 5),
+    ],
+    ids=["default parameters", "axes provided", "kwargs provided"],
+)
+def test_heatmap(frequency, ax, kwargs, expected_bins):
+    """Test heatmap y-axis, colorbar label, and kwargs forwarding across parameter combinations."""
+    mesh, cbar = plotting.heatmap(_position(), frequency=frequency, ax=ax, **kwargs)
+    used_ax = ax if ax is not None else plt.gca()
+    assert used_ax.yaxis_inverted()
+    assert cbar.ax.get_ylabel() == "time (s)"
+    arr = mesh.get_array()
+    assert arr is not None
+    assert arr.shape == (expected_bins, expected_bins)
+
+
+def test_heatmap_frequency_scales_weights():
+    """Test heatmap values are halved when frequency is doubled (weights = 1/frequency)."""
+    pos = _position()
+    mesh10, _ = plotting.heatmap(pos, frequency=10, bins=10)
+    mesh20, _ = plotting.heatmap(pos, frequency=20, bins=10)
+    arr10, arr20 = mesh10.get_array(), mesh20.get_array()
+    assert arr10 is not None
+    assert arr20 is not None
+    # each sample weighted 1/frequency, so double freq = half values
+    np.testing.assert_allclose(arr10, arr20 * 2)
+
+
+@pytest.mark.parametrize(
+    ("cx", "cy", "r", "ax"),
+    [(0, 0, 1, None), (5, 3, 10, None), (-2, -7, 0.5, plt.subplots()[1])],
+    ids=[
+        "unit circle at origin",
+        "positive center, large radius",
+        "negative center, small radius, axes provided",
+    ],
+)
+def test_circle(cx, cy, r, ax):
+    """Test circle draws 360 points lying on the circle of radius r around (cx, cy)."""
+    ax = ax if ax is not None else plt.gca()
+    plotting.circle(cx, cy, r, ax=ax)
+    line = ax.lines[0]
+    xdata = np.asarray(line.get_xdata())
+    ydata = np.asarray(line.get_ydata())
+    assert len(xdata) == 360
+    distances = np.sqrt((xdata - cx) ** 2 + (ydata - cy) ** 2)
+    np.testing.assert_allclose(distances, r)
+
+
+def test_circle_uses_current_axes_when_none():
+    """Test circle falls back to plt.gca() when no axes is provided."""
+    _, ax = plt.subplots()
+    plt.sca(ax)
+    plotting.circle(0, 0, 1)
+    assert len(ax.lines) == 1
+
+
+@pytest.mark.parametrize(
+    ("window", "frequency", "ax", "kwargs"),
+    [
+        ("5s", 10, None, {}),
+        ("10s", 20, plt.subplots()[1], {"label": "pellets rate"}),
+    ],
+    ids=["default axes", "axes provided"],
+)
+def test_rateplot(window, frequency, ax, kwargs):
+    """Test rateplot varying relevant parameters.
+
+    The parameters being left out are those passed to `analysis.utils.rate`
+    and thus tested separately in `test_utils.py`.
+    """
+    events = _events()
+    used_ax = ax if ax is not None else plt.gca()
+    n_lines_before = len(used_ax.lines)
+    n_collections_before = len(used_ax.collections)
+    plotting.rateplot(events, window=window, frequency=frequency, ax=ax, **kwargs)
+    line = used_ax.lines[n_lines_before]
+    assert np.asarray(line.get_xdata())[0] == pytest.approx(0.0)
+    assert np.all(np.asarray(line.get_ydata()) >= 0)
+    assert len(used_ax.collections) == n_collections_before + 1
+    lc = used_ax.collections[n_collections_before]
+    assert isinstance(lc, LineCollection)
+    segments = lc.get_segments()
+    assert len(segments) == len(events)
+    vline_x = np.array([seg[0, 0] for seg in segments])
+    np.testing.assert_allclose(vline_x, np.arange(len(events)) / 60.0)
+    if "label" in kwargs:
+        assert line.get_label() == kwargs["label"]
+
+
+@pytest.mark.parametrize(
+    ("bottom", "top", "expected_bottom", "expected_top"),
+    [
+        (0.1, 0.2, -0.1, 1.2),
+        (0, 0, 0.0, 1.0),
+        (0.1, 0.1, -0.1, 1.1),
+    ],
+    ids=["asymmetric margins", "zero margins", "equal margins"],
+)
+def test_set_ymargin(bottom, top, expected_bottom, expected_top):
+    """Test set_ymargin extends ylim relative to data range by specified proportions."""
+    _, ax = plt.subplots()
+    ax.plot([0, 1], [0, 1])
+    plotting.set_ymargin(ax, bottom=bottom, top=top)
+    assert ax.get_ylim() == (expected_bottom, expected_top)
+
+
+@pytest.mark.parametrize(
+    ("x", "y", "ax", "kwargs"),
+    [
+        (np.linspace(0, 1, 5), np.zeros(5), None, {}),
+        (np.array([0.0, 1.0, 0.0, -1.0, 0.0]), np.array([1.0, 0.0, -1.0, 0.0, 1.0]), plt.subplots()[1], {}),
+        (np.linspace(0, 1, 5), np.linspace(0, 1, 5), None, {"linewidth": 3}),
+    ],
+    ids=["default axes", "axes provided", "kwargs forwarded"],
+)
+def test_colorline(x, y, ax, kwargs):
+    """Test colorline builds n-1 segments with correct coordinates and applies kwargs."""
+    used_ax = ax if ax is not None else plt.gca()
+    result = plotting.colorline(x, y, ax=ax, **kwargs)
+    assert isinstance(result, LineCollection)
+    assert result in used_ax.collections
+    segs = result.get_segments()
+    assert len(segs) == len(x) - 1
+    for i, seg in enumerate(segs):
+        np.testing.assert_array_equal(seg, [[x[i], y[i]], [x[i + 1], y[i + 1]]])
+    if "linewidth" in kwargs:
+        assert np.asarray(result.get_linewidth())[0] == kwargs["linewidth"]

--- a/tests/test_unit/analysis/test_utils.py
+++ b/tests/test_unit/analysis/test_utils.py
@@ -1,5 +1,6 @@
 """Tests for the `swc.aeon.analysis.utils` module."""
 
+import pandas as pd
 import pytest
 
 from swc.aeon.analysis import utils
@@ -13,9 +14,285 @@ from tests.schema import exp02
     ids=["zero radius", "positive radius", "negative radius"],
 )
 def test_distancetravelled(monotonic_dir, radius, expected_sum):
-    """Test `distancetravelled` correctly computes the expected sum (down to the closest integer)
+    """Test distancetravelled correctly computes the expected sum (down to the closest integer)
     for the specified test file.
     """
     data = load(monotonic_dir, exp02.Patch2.Encoder)
     result = utils.distancetravelled(data.angle, radius)
     assert int(result.sum()) == expected_sum
+
+
+def _make_visits_data(ids, events, times):
+    """Build a DataFrame with named time index as input to visits()."""
+    return pd.DataFrame(
+        {"id": ids, "event": events},
+        index=pd.DatetimeIndex(pd.to_datetime(times), name="time"),
+    )
+
+
+@pytest.mark.parametrize(
+    ("ids", "events", "times", "expected"),
+    [
+        (
+            [1, 1],
+            ["Enter", "Exit"],
+            ["2022-01-01 10:00:00", "2022-01-01 10:05:00"],
+            pd.DataFrame(
+                {
+                    "id": [1],
+                    "enter": pd.to_datetime(["2022-01-01 10:00:00"]),
+                    "exit": pd.to_datetime(["2022-01-01 10:05:00"]),
+                    "duration": [pd.Timedelta("5min")],
+                }
+            ),
+        ),
+        (
+            [1, 2, 1, 2],
+            ["Enter", "Enter", "Exit", "Exit"],
+            ["2022-01-01 10:00:00", "2022-01-01 10:01:00", "2022-01-01 10:05:00", "2022-01-01 10:06:00"],
+            pd.DataFrame(
+                {
+                    "id": [1, 2],
+                    "enter": pd.to_datetime(["2022-01-01 10:00:00", "2022-01-01 10:01:00"]),
+                    "exit": pd.to_datetime(["2022-01-01 10:05:00", "2022-01-01 10:06:00"]),
+                    "duration": [pd.Timedelta("5min"), pd.Timedelta("5min")],
+                }
+            ),
+        ),
+        (
+            [1, 2, 2],
+            ["Enter", "Enter", "Exit"],
+            ["2022-01-01 10:00:00", "2022-01-01 10:01:00", "2022-01-01 10:06:00"],
+            pd.DataFrame(
+                {
+                    "id": [2],
+                    "enter": pd.to_datetime(["2022-01-01 10:01:00"]),
+                    "exit": pd.to_datetime(["2022-01-01 10:06:00"]),
+                    "duration": [pd.Timedelta("5min")],
+                }
+            ),
+        ),
+        (
+            [1, 1, 1],
+            ["Enter", "Enter", "Exit"],
+            ["2022-01-01 10:00:00", "2022-01-01 10:03:00", "2022-01-01 10:06:00"],
+            pd.DataFrame(
+                {
+                    "id": [1, 1],
+                    "enter": pd.to_datetime(["2022-01-01 10:00:00", "2022-01-01 10:03:00"]),
+                    "exit": pd.to_datetime(["NaT", "2022-01-01 10:06:00"]),
+                    "duration": pd.to_timedelta(["NaT", "3min"]),
+                }
+            ),
+        ),
+    ],
+    ids=[
+        "single pair",
+        "multiple pairs",
+        "unmatched onset dropped",
+        "multiple onsets share same offset, set earlier visit to NA",
+    ],
+)
+def test_visits(ids, events, times, expected):
+    """Test visits computes visit durations and metadata for various event sequences."""
+    data = _make_visits_data(ids=ids, events=events, times=times)
+    result = utils.visits(data)
+    pd.testing.assert_frame_equal(result, expected)
+
+
+def test_visits_custom_labels():
+    """Test visits with custom onset/offset labels."""
+    data = _make_visits_data(
+        ids=[1, 1],
+        events=["Start", "Stop"],
+        times=["2022-01-01 10:00:00", "2022-01-01 10:10:00"],
+    )
+    result = utils.visits(data, onset="Start", offset="Stop")
+    expected = pd.DataFrame(
+        {
+            "id": [1],
+            "start": pd.to_datetime(["2022-01-01 10:00:00"]),
+            "stop": pd.to_datetime(["2022-01-01 10:10:00"]),
+            "duration": [pd.Timedelta("10min")],
+        }
+    )
+    pd.testing.assert_frame_equal(result, expected)
+
+
+@pytest.mark.parametrize(
+    ("index", "start", "expected"),
+    [
+        (
+            pd.to_datetime(["2022-01-01 10:00:00", "2022-01-01 10:00:30", "2022-01-01 10:01:00"]),
+            None,
+            [0.0, 0.5, 1.0],
+        ),
+        (
+            pd.to_datetime(["2022-01-01 10:01:00", "2022-01-01 10:02:00"]),
+            pd.Timestamp("2022-01-01 10:00:00"),
+            [1.0, 2.0],
+        ),
+    ],
+    ids=["no start, use first element", "start provided"],
+)
+def test_sessiontime(index, start, expected):
+    """Test sessiontime computes elapsed time in minutes."""
+    result = utils.sessiontime(index, start)
+    assert list(result) == pytest.approx(expected)
+
+
+@pytest.mark.parametrize(
+    ("position", "target", "expected"),
+    [
+        (pd.DataFrame({"x": [3.0], "y": [4.0]}), [0.0, 0.0], [5.0]),
+        (pd.DataFrame({"x": [2.0], "y": [3.0]}), [2.0, 3.0], [0.0]),
+        (pd.DataFrame({"x": [0.0, 3.0], "y": [0.0, 4.0]}), [0.0, 0.0], [0.0, 5.0]),
+    ],
+    ids=["pythagorean triple", "distance to self", "multiple points"],
+)
+def test_distance(position, target, expected):
+    """Test distance computes the Euclidean distance from position to target."""
+    result = utils.distance(position, target)
+    assert list(result) == pytest.approx(expected)
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "expected_values"),
+    [
+        (
+            {"window": "3s", "frequency": 1},
+            [1.0, 1.5, 2.0, 8 / 3, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0],
+        ),
+        (
+            {"window": "3s", "frequency": 1, "weight": 2},
+            [2.0, 3.0, 4.0, 16 / 3, 6.0, 6.0, 6.0, 6.0, 6.0, 6.0],
+        ),
+        (
+            {"window": "3s", "frequency": 1, "smooth": "5s"},
+            [1.0, 1.5, 2.0, 9 / 4, 12 / 5, 14 / 5, 3.0, 3.0, 3.0, 3.0],
+        ),
+        (
+            {"window": "3s", "frequency": 1, "center": True},
+            [2.5, 8 / 3, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 8 / 3, 2.5],
+        ),
+    ],
+    ids=[
+        "baseline: required parameters only",
+        "optional weight=2; doubles the rate values",
+        "optional smooth=5s; applies smoothing",
+        "optional center=True; centers the window",
+    ],
+)
+def test_rate(kwargs, expected_values):
+    """Test rate varying one parameter at a time for a simple event sequence."""
+    times = pd.date_range("2022-01-01 10:00:00", periods=10, freq="1s")
+    events = pd.Series(1.0, index=times)
+    result = utils.rate(events, **kwargs)
+    expected = pd.Series(expected_values, index=times)
+    pd.testing.assert_series_equal(result, expected)
+
+
+@pytest.mark.parametrize(
+    ("start", "end"),
+    [
+        (pd.Timestamp("2022-01-01 10:00:00"), pd.Timestamp("2022-01-01 10:00:15")),
+        (pd.Timestamp("2022-01-01 10:00:00"), None),
+        (None, pd.Timestamp("2022-01-01 10:00:15")),
+    ],
+    ids=["start and end", "start only", "end only"],
+)
+def test_rate_index_bounds(start, end):
+    """Test rate extends index to start/end bounds when provided."""
+    times = pd.date_range("2022-01-01 10:00:05", periods=5, freq="1s")
+    events = pd.Series(dtype=float, index=times)
+    result = utils.rate(events, window="3s", frequency=1, start=start, end=end)
+    if start is not None:
+        assert result.index[0] == start
+    if end is not None:
+        assert result.index[-1] == end
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "expected_values"),
+    [
+        (
+            {"window_len_sec": 5, "frequency": "1s"},
+            [12.0, 18.0, 24.0, 30.0, 36.0, 228 / 5, 264 / 5, 288 / 5, 60.0, 60.0],
+        ),
+        (
+            {"window_len_sec": 5, "frequency": "1s", "unit_len_sec": 1},
+            [1 / 5, 3 / 10, 2 / 5, 1 / 2, 3 / 5, 19 / 25, 22 / 25, 24 / 25, 1.0, 1.0],
+        ),
+        (
+            {"window_len_sec": 5, "frequency": "1s", "smooth": "3s"},
+            [12.0, 18.0, 24.0, 36.0, 48.0, 56.0, 60.0, 60.0, 60.0, 60.0],
+        ),
+        (
+            {"window_len_sec": 5, "frequency": "1s", "center": True},
+            [48.0, 51.0, 264 / 5, 288 / 5, 60.0, 60.0, 288 / 5, 264 / 5, 51.0, 48.0],
+        ),
+    ],
+    ids=[
+        "baseline: required parameters only",
+        "unit_len_sec=1; scales values down by 60 (default is 60s)",
+        "smooth=3s; applies smoothing",
+        "center=True; centers the window",
+    ],
+)
+def test_get_events_rates(kwargs, expected_values):
+    """Test get_events_rates varying one parameter at a time for a simple event sequence."""
+    times = pd.date_range("2022-01-01 10:00:00", periods=10, freq="1s")
+    events = pd.Series(1.0, index=times)
+    result = utils.get_events_rates(events, **kwargs)
+    expected = pd.Series(expected_values, index=times)
+    pd.testing.assert_series_equal(result, expected)
+
+
+@pytest.mark.parametrize(
+    ("start", "end"),
+    [
+        (pd.Timestamp("2022-01-01 10:00:00"), pd.Timestamp("2022-01-01 10:00:15")),
+        (pd.Timestamp("2022-01-01 10:00:00"), None),
+        (None, pd.Timestamp("2022-01-01 10:00:15")),
+    ],
+    ids=["start and end", "start only", "end only"],
+)
+def test_get_events_rates_index_bounds(start, end):
+    """Test get_events_rates extends index to start/end bounds when provided."""
+    times = pd.date_range("2022-01-01 10:00:05", periods=5, freq="1s")
+    events = pd.Series(1.0, index=times)
+    result = utils.get_events_rates(events, window_len_sec=5, frequency="1s", start=start, end=end)
+    if start is not None:
+        assert result.index[0] == start
+    if end is not None:
+        assert result.index[-1] == end
+
+
+@pytest.mark.parametrize(
+    ("wheel", "in_patch", "expected"),
+    [
+        (
+            [0.0, 2.0, 2.0, 2.0, 2.0],
+            [True, True, True, True, True],
+            [False, True, True, True, True],
+        ),
+        (
+            [0.0, 0.0, 0.0, 0.0, 0.0],
+            [True, True, True, True, True],
+            [False, False, False, False, False],
+        ),
+        (
+            [0.0, 2.0, 0.0, 0.0, 0.0],
+            [True, True, False, True, True],
+            [False, True, False, False, False],
+        ),
+    ],
+    ids=["wheel active", "wheel inactive", "epoch reset: wheel active only in first epoch"],
+)
+def test_activepatch(wheel, in_patch, expected):
+    """Test activepatch identifies active patch periods based on wheel movement and in_patch status."""
+    times = pd.date_range("2022-01-01", periods=5, freq="200ms")
+    wheel = pd.Series(wheel, index=times)
+    in_patch = pd.Series(in_patch, index=times)
+    result = utils.activepatch(wheel, in_patch)
+    assert list(result.values) == expected


### PR DESCRIPTION
This PR adds unit tests for all analysis modules.
This PR also fixes #81 (uncovered when adding unit test).

## Questions
- L81 and L86 below remain uncovered because the docstring states that `before` and `after` should be `pd.Timedelta`. Should we simplify by assuming `before` and `after` are `pd.Timedelta` and remove the `not isinstance` cases?
https://github.com/SainsburyWellcomeCentre/aeon_api/blob/567bcfe4aa6b5a2ac19941b678787e489a04e199/src/swc/aeon/analysis/movies.py#L68-L86

- in `groupframes`, the incomplete final group is silently dropped. I [added a note in the docstring](https://github.com/SainsburyWellcomeCentre/aeon_api/pull/82/changes/f562c8f042f7c1624d17cb30bff10cce1ad3e098) to mention this. I guess we keep this behaviour as is to guarantee complete groups with exactly `n` frames are being passed to `fun`, rather than trying to handle partial groups?
https://github.com/SainsburyWellcomeCentre/aeon_api/blob/567bcfe4aa6b5a2ac19941b678787e489a04e199/src/swc/aeon/analysis/movies.py#L50-L65