### PR TITLE
Update codecov-action to v6 in CI workflow

### DIFF
--- a/.github/workflows/swc-aeon.yml
+++ b/.github/workflows/swc-aeon.yml
@@ -71,7 +71,7 @@ jobs:
       # -------------------------------------------------------- Coverage report
       - name: Upload test coverage report to codecov
         if: ${{ matrix.codecov }}
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           directory: tests/test_coverage/

--- a/.github/workflows/swc-aeon.yml
+++ b/.github/workflows/swc-aeon.yml
@@ -26,7 +26,7 @@ jobs:
               name: Linux
               os: ubuntu-latest
             python-version: "3.13"
-            codecov: --cov-report=xml:tests/test_coverage/test_coverage_report.xml
+            codecov: --cov-report=xml
             collect-packages: true
           - platform:
               name: Windows
@@ -74,8 +74,6 @@ jobs:
         uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          directory: tests/test_coverage/
-          files: test_coverage_report.xml
           fail_ci_if_error: true
           verbose: true
 


### PR DESCRIPTION
- uses latest codecov action
- also used for testing codecov upload behaviour
(continuing #76 )