### PR TITLE
Add data range filtering for non-monotonic index

### DIFF
--- a/src/swc/aeon/io/api.py
+++ b/src/swc/aeon/io/api.py
@@ -336,7 +336,11 @@ def load(
                 warnings.warn(
                     f"data index for {reader.pattern} contains out-of-order timestamps!", stacklevel=2
                 )
-                data = data.sort_index()
+                idx = data.index
+                lo = (idx >= start if inclusive in ("both", "left") else idx > start) if start is not None else None
+                hi = (idx <= end if inclusive in ("both", "right") else idx < end) if end is not None else None
+                mask = lo if hi is None else hi if lo is None else lo & hi
+                return data[mask]
             else:  # pragma: no cover
                 raise
     return data


### PR DESCRIPTION
This PR fixes the issue described in #89

## Problem
When a chunk contains out-of-order timestamps (e.g. a Harp clock glitch emitting one timestamp ~1 s ahead), `_filter_time_range` raises KeyError from `frame.loc[start:end]` on the non-monotonic DatetimeIndex. The `except` branch sorted the index but then fell through to `return data`, returning the entire loaded range and silently ignoring the requested [start, end] window.

## Fix
Select rows by timestamp value with a boolean mask instead of sorting. This keeps the try/except, respects `inclusive`, and preserves original row order so glitched out-of-order timestamps stay in place for downstream correction rather than being reordered.

Fixes #89 